### PR TITLE
Errors with empty files

### DIFF
--- a/lib/Platform/Docker/Container.pm6
+++ b/lib/Platform/Docker/Container.pm6
@@ -128,12 +128,10 @@ class Platform::Docker::Container is Platform::Container {
                     $mode    = $content<mode>  if $content<mode>;
                     $content = $content<content>;
                     temp $path = $path.IO.dirname;
-					$content = "$path/$content".IO.slurp if $content && "$path/$content".IO.e;
+                    $content = "$path/$content".IO.slurp if $content && "$path/$content".IO.e;
                 }
             }
-			if (! $content) {
-				$content = '';
-			}
+            $content = '' unless $content;
             my $file_tpl = "$path/{self.name}/" ~ $target;
             mkdir $file_tpl.IO.dirname;
             spurt $file_tpl, $content;

--- a/lib/Platform/Docker/Container.pm6
+++ b/lib/Platform/Docker/Container.pm6
@@ -128,9 +128,12 @@ class Platform::Docker::Container is Platform::Container {
                     $mode    = $content<mode>  if $content<mode>;
                     $content = $content<content>;
                     temp $path = $path.IO.dirname;
-                    $content = "$path/$content".IO.slurp if "$path/$content".IO.e;
+					$content = "$path/$content".IO.slurp if $content && "$path/$content".IO.e;
                 }
             }
+			if (! $content) {
+				$content = '';
+			}
             my $file_tpl = "$path/{self.name}/" ~ $target;
             mkdir $file_tpl.IO.dirname;
             spurt $file_tpl, $content;


### PR DESCRIPTION
When file content wasn't declared(file was wanted to be touched) or it was empty, there was some nasty errors that prevented of building docker containers.