### PR TITLE
Setup test docker check is always true

### DIFF
--- a/t/99-setup.t
+++ b/t/99-setup.t
@@ -7,9 +7,9 @@ use nqp;
 
 plan 6;
 
-constant DOCKER = ( ( run <docker --version>, :out, :err ).out.slurp ~~ / ^ Docker / ).Bool;
+constant DOCKER = ( run "docker", "ps", :out, :err).exitcode;
 
-if not DOCKER {
+if DOCKER.Bool {
      skip-rest "Skipping tests because docker is not available";
      exit;
 }


### PR DESCRIPTION
the result of docker --version is always the same even if docker is stopped changed to docker ps and used exitcode check